### PR TITLE
Skill buy refactor

### DIFF
--- a/src/components/FormView/FormView.jsx
+++ b/src/components/FormView/FormView.jsx
@@ -24,8 +24,7 @@ function FormView() {
     const [confirmedStats, setConfirmedStats] = useState(false)
     const [availableSkills, setAvailableSkills] = useState([])
     const [selectedSkills, setSelectedSkills] = useState({})
-    const [skillPointsLeft, setSkillPointsLeft] = useState(3)
-    const [selectedLanguages, setSelectedLanguages] = useState([]);
+    const [selectedLanguages, setSelectedLanguages] = useState([])
 
         useEffect(() => {
             if (!selectedClass) return

--- a/src/components/FormView/FormView.jsx
+++ b/src/components/FormView/FormView.jsx
@@ -174,6 +174,9 @@ function FormView() {
                         const skillBonus = baseMod + assignedSkillPoints
                         const formattedBonus = skillBonus >= -1 ? `${skillBonus}` : `${skillBonus}`
 
+                        // Count currently selected proficiencies
+                        const selectedCount = Object.values(selectedSkills).filter(val => val === 2).length;
+
                         return (
                             <div key={skill.name} className="skill-card">
                                 <h4>{skill.name} | {assignedSkillPoints}</h4>
@@ -185,14 +188,17 @@ function FormView() {
                                         <input
                                             type="checkbox"
                                             checked={assignedSkillPoints >= 2}
+                                            disabled={
+                                                !assignedSkillPoints &&
+                                                selectedCount >= 3
+                                            }
                                             onChange={(event) => {
-                                                const isSelected = event.target.checked
-                                                setSelectedSkills(previousState => ({
-                                                    ...previousState,
-                                                    [skill.name] : isSelected ? 2 : 0
-                                                }))
+                                                const isSelected = event.target.checked;
+                                                setSelectedSkills(prev => ({
+                                                    ...prev,
+                                                    [skill.name]: isSelected ? 2 : 0
+                                                }));
                                             }}
-                                        
                                         />
                                         +2 (proficiencyBonus)
                                     </label>

--- a/src/components/SheetView/SheetView.jsx
+++ b/src/components/SheetView/SheetView.jsx
@@ -34,7 +34,7 @@ const SheetView = () => {
         <p><strong>AC:</strong> {character?.armor || "N/A"}</p>
         <p><strong>HP:</strong> {character?.Hp || character?.hp || "N/A"}</p>
         <p><strong>Speed:</strong> {character?.speed ? `${character.speed} ft` : "N/A"}</p>
-        <p><strong>Proficiency:</strong> +{character?.proficiency || +2}</p>
+        <p><strong>Proficiency Bonus:</strong> +{character?.proficiency || +2}</p>
         <p><strong>Languages:</strong> {Array.isArray(character?.languages) ? character.languages.join(', ') : "N/A"}</p>
       </section>
 
@@ -71,9 +71,38 @@ const SheetView = () => {
           {character?.skills && Object.keys(character.skills).length > 0 && (
             <>
               <li><strong>Skills:</strong></li>
-                {Object.entries(character.skills).map(([skill, value], index) => (
-              <li key={`skill-${index}`}>{skill}: +{value > 0 ? 2 : 0}</li>
-              ))}
+              {Object.entries(character.skills).map(([skill, value], index) => {
+                const skillStatMap = {
+                  Athletics: 'Strength',
+                  Acrobatics: 'Dexterity',
+                  Stealth: 'Dexterity',
+                  Arcana: 'Intelligence',
+                  History: 'Intelligence',
+                  Investigation: 'Intelligence',
+                  Nature: 'Intelligence',
+                  Religion: 'Intelligence',
+                  AnimalHandling: 'Wisdom',
+                  Insight: 'Wisdom',
+                  Medicine: 'Wisdom',
+                  Perception: 'Wisdom',
+                  Survival: 'Wisdom',
+                  Deception: 'Charisma',
+                  Intimidation: 'Charisma',
+                  Performance: 'Charisma',
+                  Persuasion: 'Charisma'
+                };
+
+                const relatedStat = skillStatMap[skill]
+                const statValue = character?.stats?.[relatedStat] || 8
+                const statModifier = Math.floor((statValue - 10) / 2)
+                const totalBonus = statModifier + (value || 0)
+                const cappedBonus = Math.max(totalBonus, 3)
+                const displayedBonus = cappedBonus >= 0 ? `+${cappedBonus}` : cappedBonus
+
+                return (
+                  <li key={`${skillStatMap}-${index}`}>{skill}: {displayedBonus}</li>
+                )
+              })}
             </>
           )}
         </ul>     


### PR DESCRIPTION
Added proficiency bonus to Character sheet / displaying image of token on sheet

- A user can now see all the skills that they are proficient in as well as the list of the skills for dice rolls and other needs
- A user is able to select UP TO 3 skills they want to be proficient in
- A user can now get a fully filled out character sheet that they could take to any campaign

<img width="679" alt="Screenshot 2025-04-23 at 8 21 31 PM" src="https://github.com/user-attachments/assets/e93d38a6-0088-4c37-9fcc-464af9be943d" />


